### PR TITLE
Enable connecting to github using SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,36 @@ Plugin to homebridge, adding accessory into homekit, where you can backup define
 
 _Recommend create second backuper credentials into github with access into backup repository._
 
-###### Example config:
+
+###### Example Http config:
     "platforms": [
         {
             "accessory": "Github Backuper",
             "platform": "Github Backuper",
+			"conenctMethod": "https" #defaults to https
             "githubUsername": "", #github login
             "githubPassword": "", # github password
             "githubRepository": "", # example: PilarJ/homebridge-github-backup.git
             "githubName": "Jakub Pilař", # display name in github
             "githubEmail": "pilarjakub@centrum.cz", # github email
+	    	"branch": "main", #defaults to main
+            "filesToBackup": [
+                "/var/lib/homebridge/config.json"
+            ]
+        }
+    ]
+
+SSH configuration removes the need for storing your password in the config file.  You need to ensure that the user (usually homebridge) has a ssh key configured and the public key has been added to your github profile
+###### Example SSH config:
+    "platforms": [
+        {
+            "accessory": "Github Backuper",
+            "platform": "Github Backuper",
+	    	"connectMethod": "ssh",
+            "githubRepository": "", # example: PilarJ/homebridge-github-backup.git
+            "githubName": "Jakub Pilař", # display name in github
+            "githubEmail": "pilarjakub@centrum.cz", # github email
+	    	"branch": "main", #defaults to main
             "filesToBackup": [
                 "/var/lib/homebridge/config.json"
             ]

--- a/src/index.js
+++ b/src/index.js
@@ -70,9 +70,13 @@ class Backuper {
 		const email = this.config.githubEmail;
 		const name = this.config.githubName;
 		const filesToBackup = this.config.filesToBackup;
-		const branch = this.config.branch || 'master';
+		const branch = this.config.branch || 'main';
+		const connectMethod  = this.config.connectMethod || "https";
 
-		const gitHubUrl = `https://${username}:${password}@github.com/${repo}`;
+		let gitHubUrl = `https://${username}:${password}@github.com/${repo}`;
+		if(connectMethod == 'ssh'){
+			gitHubUrl = `git@github.com:${repo}`;
+		}
 
 		if (!filesToBackup || !Array.isArray(filesToBackup)) {
 			this.log.error('Missing array filesToBackup in config.');
@@ -92,6 +96,7 @@ class Backuper {
 			.then(() => simpleGitPromise.addConfig('user.name', name))
 			.then(() => simpleGitPromise.fetch())
 			.then(() => simpleGitPromise.pull(originName, branch, {'--ff': null}))
+			.then(() => simpleGitPromise.branch(['-M', `${branch}`]))
 			.then(() => simpleGitPromise.reset('hard', `${originName}/${branch}`))
 			.then(
 				// copy files to backup


### PR DESCRIPTION
Connecting with ssh removes the need to store your password in the configuration file.
Set the default branch if not specified to 'main' to match the current configuration at github.
Added a branch command to the git calls